### PR TITLE
JBDS-3032 remove m2e.jdt from JBoss Central and move to JBDS TP

### DIFF
--- a/jbdevstudio/com.jboss.jbds.central.discovery/plugin.xml
+++ b/jbdevstudio/com.jboss.jbds.central.discovery/plugin.xml
@@ -680,25 +680,6 @@ reasonable, reporting issues to these providers as required.</description>
             categoryId="org.jboss.tools.central.discovery.d.maven"
             groupId="org.jboss.tools.central.discovery.d.maven.configurators"
             certificationId="com.jboss.jbds.discovery.certification.supported"
-            description="Maven JDT Compiler Configurator (maven-compiler-plugin)"
-            id="m2e.jdt"
-            kind="task"
-            license="EPL (Free)"
-            name="Maven JDT Compiler Configurator"
-            provider="JBoss by Red Hat"
-            siteUrl="${jboss.discovery.site.url:https://devstudio.jboss.com/updates/8.0-development/central/core/}">
-            <iu id="org.jboss.tools.m2e.jdt.feature"/>
-         <icon
-               image32="images/jbosstools_icon32.png">
-         </icon>
-         <overview
-               url="http://tools.jboss.org/">
-         </overview>
-      </connectorDescriptor>
-      <connectorDescriptor
-            categoryId="org.jboss.tools.central.discovery.d.maven"
-            groupId="org.jboss.tools.central.discovery.d.maven.configurators"
-            certificationId="com.jboss.jbds.discovery.certification.supported"
             description="JBoss Tools Maven Packaging Configurator"
             id="org.jboss.tools.maven.jbosspackaging.feature"
             kind="task"

--- a/jbosstools/org.jboss.tools.central.discovery/plugin.xml
+++ b/jbosstools/org.jboss.tools.central.discovery/plugin.xml
@@ -617,24 +617,6 @@
       <connectorDescriptor
             categoryId="org.jboss.tools.central.discovery.d.maven"
             groupId="org.jboss.tools.central.discovery.d.maven.configurators"
-            description="Maven JDT Compiler Configurator (maven-compiler-plugin)"
-            id="m2e.jdt"
-            kind="task"
-            license="EPL (Free)"
-            name="Maven JDT Compiler Configurator"
-            provider="JBoss by Red Hat"
-            siteUrl="${jboss.discovery.site.url:http://download.jboss.org/jbosstools/updates/development/luna/central/core/}">
-            <iu id="org.jboss.tools.m2e.jdt.feature"/>
-         <icon
-               image32="images/jbosstools_icon32.png">
-         </icon>
-         <overview
-               url="http://tools.jboss.org/">
-         </overview>
-      </connectorDescriptor>
-      <connectorDescriptor
-            categoryId="org.jboss.tools.central.discovery.d.maven"
-            groupId="org.jboss.tools.central.discovery.d.maven.configurators"
             description="JBoss Tools Maven Packaging Configurator"
             id="org.jboss.tools.maven.jbosspackaging.feature"
             kind="task"

--- a/jbtcentraltarget/multiple/jbtcentral-multiple.target
+++ b/jbtcentraltarget/multiple/jbtcentral-multiple.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.6"?><target includeMode="feature" name="jbtcentral-4.40.0.Beta3-SNAPSHOT">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.6"?><target includeMode="feature" name="jbtcentral-4.40.0.Beta4-SNAPSHOT">
   <!-- Pro tip: paste content from generated Apache directory index, then match
         \[ ] (.+)_(.+).jar.+
     replace with 
@@ -39,11 +39,6 @@
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/m2eclipse-egit/0.14.0.201404242142/"/>
       <unit id="org.sonatype.m2e.egit.feature.feature.group" version="0.14.0.201404242142"/>
-    </location>
-    <!-- JBIDE-16757 move m2e.jdt to Central (was in JBDS TP) -->
-    <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-jdt-compiler/"/>
-      <unit id="org.jboss.tools.m2e.jdt.feature.feature.group" version="1.0.1.201209200903"/>
     </location>
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
       <repository location="http://download.jboss.org/jbosstools/updates/m2e-extensions/m2e-wro4j/1.1.0-2014-03-24_15-15-15-H24/"/>

--- a/jbtcentraltarget/multiple/pom.xml
+++ b/jbtcentraltarget/multiple/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.tools.targetplatforms</groupId>
     <artifactId>jbtcentral</artifactId>
-    <version>4.40.0.Beta3-SNAPSHOT</version>
+    <version>4.40.0.Beta4-SNAPSHOT</version>
   </parent>
   <artifactId>jbtcentral-multiple</artifactId>
   <name>JBoss Central Core Multiple (Composite) Target Platform</name>

--- a/jbtcentraltarget/pom.xml
+++ b/jbtcentraltarget/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbtcentral</artifactId>
-	<version>4.40.0.Beta3-SNAPSHOT</version>
+	<version>4.40.0.Beta4-SNAPSHOT</version>
 	<name>JBoss Central Core Target Platforms</name>
 	<packaging>pom</packaging>
 

--- a/jbtcentraltarget/unified/pom.xml
+++ b/jbtcentraltarget/unified/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.tools.targetplatforms</groupId>
     <artifactId>jbtcentral</artifactId>
-    <version>4.40.0.Beta3-SNAPSHOT</version>
+    <version>4.40.0.Beta4-SNAPSHOT</version>
   </parent>
   <artifactId>jbtcentral-unified</artifactId>
   <name>JBoss Central Core Unified (Aggregate) Target Platform</name>

--- a/jbtearlyaccesstarget/multiple/jbtearlyaccess-multiple.target
+++ b/jbtearlyaccesstarget/multiple/jbtearlyaccess-multiple.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.6"?><target includeMode="feature" name="jbtearlyaccess-4.40.0.Beta3-SNAPSHOT">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.6"?><target includeMode="feature" name="jbtearlyaccess-4.40.0.Beta4-SNAPSHOT">
   <!-- Pro tip: paste content from generated Apache directory index, then match
         \[ ] (.+)_(.+).jar.+
     replace with 

--- a/jbtearlyaccesstarget/multiple/pom.xml
+++ b/jbtearlyaccesstarget/multiple/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.tools.targetplatforms</groupId>
     <artifactId>jbtearlyaccess</artifactId>
-    <version>4.40.0.Beta3-SNAPSHOT</version>
+    <version>4.40.0.Beta4-SNAPSHOT</version>
   </parent>
   <artifactId>jbtearlyaccess-multiple</artifactId>
   <name>JBoss Central Early Access Multiple (Composite) Target Platform</name>

--- a/jbtearlyaccesstarget/pom.xml
+++ b/jbtearlyaccesstarget/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbtearlyaccess</artifactId>
-	<version>4.40.0.Beta3-SNAPSHOT</version>
+	<version>4.40.0.Beta4-SNAPSHOT</version>
 	<name>JBoss Central Early Access Target Platforms</name>
 	<packaging>pom</packaging>
 

--- a/jbtearlyaccesstarget/unified/pom.xml
+++ b/jbtearlyaccesstarget/unified/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jboss.tools.targetplatforms</groupId>
     <artifactId>jbtearlyaccess</artifactId>
-    <version>4.40.0.Beta3-SNAPSHOT</version>
+    <version>4.40.0.Beta4-SNAPSHOT</version>
   </parent>
   <artifactId>jbtearlyaccess-unified</artifactId>
   <name>JBoss Central Early Access Unified (Aggregate) Target Platform</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.tools</groupId>
     <artifactId>parent</artifactId>
-    <version>4.2.0.Beta3-SNAPSHOT</version>
+    <version>4.2.0.Beta4-SNAPSHOT</version>
   </parent>
   <groupId>org.jboss.tools.central</groupId>
   <artifactId>discovery</artifactId>


### PR DESCRIPTION
remove Maven JDT Compiler Configurator (org.jboss.tools.m2e.jdt.feature) from Central plugins (JBDS-3032) - now in JBDS TP >> master
