### PR TITLE
JBIDE-19038 remove Arquillian from JBT Central's EA site - it can be found on the JBT update site so don't need it in Central/EA >> jbosstools-4.2.x

### DIFF
--- a/jbosstools/org.jboss.tools.central.discovery.earlyaccess/plugin.xml
+++ b/jbosstools/org.jboss.tools.central.discovery.earlyaccess/plugin.xml
@@ -44,52 +44,7 @@ but this is not guaranteed.</description>
          </overview>
       </connectorDescriptor>
 
-      <connectorDescriptor
-            categoryId="org.jboss.tools.central.discovery.a.web"
-            groupId="org.jboss.tools.central.discovery.a.web.core"
-            certificationId="org.jboss.tools.discovery.certification.earlyaccess"
-            description="Create and run tests with Arquillian"
-            id="org.jboss.tools.arquillian"
-            kind="task"
-            license="EPL (Free)"
-            name="JBoss Arquillian Tools"
-            provider="JBoss by Red Hat"
-            siteUrl="${jboss.discovery.earlyaccess.site.url:http://download.jboss.org/jbosstools/earlyaccess/development/luna/}">
-            <iu id="org.jboss.tools.arquillian.feature"/>
-         <icon image32="images/arquillian_32.png"/>
-         <overview url="http://www.jboss.org/tools"/>
-      </connectorDescriptor>
-
-      <!-- JBIDE-14122: VJET added -->
-      <!-- JBIDE-18449: VJET removed
-      <connectorDescriptor
-            categoryId="org.jboss.tools.central.discovery.a.web"
-            groupId="org.jboss.tools.central.discovery.a.web.extras2"
-            certificationId="org.jboss.tools.discovery.certification.earlyaccess"
-            description="Eclipse VJET (Experimental) includes a JavaScript IDE, Java to Javascript Code Generation + Java Based DOM Kit"
-            id="org.eclipse.vjet.feature"
-            kind="task"
-            license="EPL, Other (Free)"
-            name="Eclipse VJET"
-            provider="eclipse.org"
-            siteUrl="${jboss.discovery.earlyaccess.site.url:http://download.jboss.org/jbosstools/updates/development/luna/central/earlyaccess/}">
-            <iu id="org.eclipse.vjet.core"/>
-            <iu id="org.eclipse.vjet.eclipse"/>
-            <iu id="org.eclipse.vjet.extmod.dltk.core"/>
-            <iu id="org.eclipse.vjet.extmod.jsdt"/>
-            <iu id="org.eclipse.vjet.extmod.rhino"/>
-            <iu id="org.eclipse.vjet.rt"/>
-            <iu id="org.eclipse.vjet.web"/>
-            <iu id="org.eclipse.vjet.codegen"/>
-            <iu id="org.eclipse.vjet.vsf.domkit"/>
-            <iu id="org.eclipse.equinox.server.jetty"/>
-         <icon
-               image32="images/vjet_32.png">
-         </icon>
-         <overview
-               url="http://www.eclipse.org/vjet">
-         </overview>
-      </connectorDescriptor> -->
-
-    </extension>	
+      <!-- JBIDE-19038: Arquillian is not EA in JBT, only in JBDS, so move connector to ../org.jboss.tools.central.discovery/plugin.xml and remove certificationId=earlyaccess
+      -->
+    </extension>
 </plugin>

--- a/jbosstools/org.jboss.tools.central.discovery/plugin.xml
+++ b/jbosstools/org.jboss.tools.central.discovery/plugin.xml
@@ -95,6 +95,22 @@
          <group id="org.jboss.tools.central.discovery.a.web.extras2" />
       </connectorCategory>
 
+      <!-- JBIDE-19038: Arquillian is not EA in JBT, only in JBDS -->
+      <connectorDescriptor
+            categoryId="org.jboss.tools.central.discovery.a.web"
+            groupId="org.jboss.tools.central.discovery.a.web.core"
+            description="Create and run tests with Arquillian"
+            id="org.jboss.tools.arquillian"
+            kind="task"
+            license="EPL (Free)"
+            name="JBoss Arquillian Tools"
+            provider="JBoss by Red Hat"
+            siteUrl="${jboss.discovery.earlyaccess.site.url:http://download.jboss.org/jbosstools/updates/development/luna/central/core/}">
+            <iu id="org.jboss.tools.arquillian.feature"/>
+         <icon image32="images/arquillian_32.png"/>
+         <overview url="http://www.jboss.org/tools"/>
+      </connectorDescriptor> 
+
       <connectorDescriptor
             categoryId="org.jboss.tools.central.discovery.a.web"
             groupId="org.jboss.tools.central.discovery.a.web.core"

--- a/jbtcentraltarget/multiple/jbtcentral-multiple.target
+++ b/jbtcentraltarget/multiple/jbtcentral-multiple.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.6"?><target includeMode="feature" name="jbtcentral-4.41.2.CR1-SNAPSHOT">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.6"?><target includeMode="feature" name="jbtcentral-4.41.3.CR1-SNAPSHOT">
   <!-- Pro tip: paste content from generated Apache directory index, then match
         \[ ] (.+)_(.+).jar.+
     replace with 

--- a/jbtcentraltarget/pom.xml
+++ b/jbtcentraltarget/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbtcentral</artifactId>
-	<version>4.41.2.Final-SNAPSHOT</version>
+	<version>4.41.3.CR1-SNAPSHOT</version>
 	<name>JBoss Central Core Target Platforms</name>
 	<packaging>pom</packaging>
 

--- a/jbtearlyaccesstarget/multiple/jbtearlyaccess-multiple.target
+++ b/jbtearlyaccesstarget/multiple/jbtearlyaccess-multiple.target
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.6"?><target includeMode="feature" name="jbtearlyaccess-4.41.2.CR1-SNAPSHOT">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.6"?><target includeMode="feature" name="jbtearlyaccess-4.41.3.CR1-SNAPSHOT">
   <!-- Pro tip: paste content from generated Apache directory index, then match
         \[ ] (.+)_(.+).jar.+
     replace with 

--- a/jbtearlyaccesstarget/pom.xml
+++ b/jbtearlyaccesstarget/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbtearlyaccess</artifactId>
-	<version>4.41.2.Final-SNAPSHOT</version>
+	<version>4.41.3.CR1-SNAPSHOT</version>
 	<name>JBoss Central Early Access Target Platforms</name>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
This PR comments out Arquillian from teh EA discovery plugin, and removes the old commented out VJET stuff too. Figured while I was performing surgery on the colon I could remove the appendix, too.