### PR TITLE
[JBIDE-19186] Update angularjs-eclipse to 0.8.0 release

### DIFF
--- a/jbtearlyaccesstarget/multiple/jbtearlyaccess-multiple.target
+++ b/jbtearlyaccesstarget/multiple/jbtearlyaccess-multiple.target
@@ -13,8 +13,8 @@
     -->
 
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/angularjs/0.8.0.201501200034-SNAPSHOT/"/>
-      <unit id="angularjs-eclipse-feature.feature.group" version="0.8.0.201501200034"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/angularjs/0.8.0.201501282321"/>
+      <unit id="angularjs-eclipse-feature.feature.group" version="0.8.0.201501282321"/>
     </location>
 
     <!-- TODO: update this with each milestone release -->


### PR DESCRIPTION
Fix updates angular in central to 0.8.0.201501282321