### PR TITLE
Fix for ejbtearlyaccess build

### DIFF
--- a/jbtearlyaccesstarget/pom.xml
+++ b/jbtearlyaccesstarget/pom.xml
@@ -13,11 +13,6 @@
 	<name>JBoss Central Early Access Target Platforms</name>
 	<packaging>pom</packaging>
 
-	<properties>
-		<tychoVersion>0.23.1</tychoVersion>
-		<tychoExtrasVersion>${tychoVersion}</tychoExtrasVersion>
-	</properties>
-
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
fix removes properties to override tycho versions and they going to be taken from
parent/pom.xml
