### PR TITLE
Revert JBIDE-22148 to use right jrebel site

### DIFF
--- a/jbdevstudio/com.jboss.jbds.central.discovery/plugin.xml
+++ b/jbdevstudio/com.jboss.jbds.central.discovery/plugin.xml
@@ -594,7 +594,7 @@ reasonable, reporting issues to these providers as required.</description>
             license="Commercial"
             name="JRebel"
             provider="zeroturnaround.org"
-            siteUrl="http://update.zeroturnaround.com/update-site/">
+            siteUrl="http://update.zeroturnaround.com/update-site-jboss/">
             <iu id="org.zeroturnaround.eclipse.feature"/>
             <iu id="org.zeroturnaround.eclipse.wtp.feature"/>
             <iu id="org.zeroturnaround.eclipse.m2e.feature"/>

--- a/jbosstools/org.jboss.tools.central.discovery/plugin.xml
+++ b/jbosstools/org.jboss.tools.central.discovery/plugin.xml
@@ -551,7 +551,7 @@
             license="Commercial"
             name="JRebel"
             provider="zeroturnaround.org"
-            siteUrl="http://update.zeroturnaround.com/update-site/">
+            siteUrl="http://update.zeroturnaround.com/update-site-jboss/">
             <iu id="org.zeroturnaround.eclipse.feature"/>
             <iu id="org.zeroturnaround.eclipse.wtp.feature"/>
             <iu id="org.zeroturnaround.eclipse.m2e.feature"/>


### PR DESCRIPTION

This reverts commit 5e6fe574836e260ec47445abe2514fd7f8193540
which restore use of the jboss jrebel updatesite.