### PR TITLE
JBIDE-24484 Free Marker IDE IU ID changed to org.jboss.ide.eclipse.freemarker.feature

### DIFF
--- a/jbdevstudio/com.jboss.jbds.central.discovery/plugin.xml
+++ b/jbdevstudio/com.jboss.jbds.central.discovery/plugin.xml
@@ -186,7 +186,7 @@ reasonable, reporting issues to these providers as required.</description>
             name="FreeMarker IDE"
             provider="JBoss by Red Hat"
             siteUrl="${jboss.discovery.site.url}">
-        <iu id="org.jboss.tools.freemarker.feature"/>
+        <iu id="org.jboss.ide.eclipse.freemarker.feature"/>
         <icon image32="images/jbosstools_icon32.png"/>
         <overview url="http://www.jboss.org/tools"/>
       </connectorDescriptor> 

--- a/jbosstools/org.jboss.tools.central.discovery/plugin.xml
+++ b/jbosstools/org.jboss.tools.central.discovery/plugin.xml
@@ -167,7 +167,7 @@ Supported by Red Hat.</description>
             name="FreeMarker IDE"
             provider="JBoss by Red Hat"
             siteUrl="${jboss.discovery.site.url}">
-        <iu id="org.jboss.tools.freemarker.feature"/>
+        <iu id="org.jboss.ide.eclipse.freemarker.feature"/>
         <icon image32="images/jbosstools_icon32.png"/>
         <overview url="http://www.jboss.org/tools"/>
       </connectorDescriptor> 


### PR DESCRIPTION
JBIDE-24484 Free Marker IDE IU ID changed to org.jboss.ide.eclipse.freemarker.feature (because feature org.jboss.tools.freemarker.feature doesn't exist).