### PR TITLE
Set devstudio discovery version to 11.1.0

### DIFF
--- a/devstudio/com.jboss.devstudio.central.discovery.earlyaccess/META-INF/MANIFEST.MF
+++ b/devstudio/com.jboss.devstudio.central.discovery.earlyaccess/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: com.jboss.devstudio.central.discovery.earlyaccess;singleton:=true
-Bundle-Version: 11.0.0.qualifier
+Bundle-Version: 11.1.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.mylyn.discovery.core;bundle-version="3.6.0"
 Bundle-ActivationPolicy: lazy

--- a/devstudio/com.jboss.devstudio.central.discovery.earlyaccess/pom.xml
+++ b/devstudio/com.jboss.devstudio.central.discovery.earlyaccess/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <groupId>com.jboss.devstudio.core.plugins</groupId>
   <artifactId>com.jboss.devstudio.central.discovery.earlyaccess</artifactId> 
-  <version>11.0.0-SNAPSHOT</version>
+  <version>11.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 <build>
     <plugins>

--- a/devstudio/com.jboss.devstudio.central.discovery/META-INF/MANIFEST.MF
+++ b/devstudio/com.jboss.devstudio.central.discovery/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: com.jboss.devstudio.central.discovery;singleton:=true
-Bundle-Version: 11.0.0.qualifier
+Bundle-Version: 11.1.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.mylyn.discovery.core;bundle-version="3.6.0"
 Bundle-ActivationPolicy: lazy

--- a/devstudio/com.jboss.devstudio.central.discovery/pom.xml
+++ b/devstudio/com.jboss.devstudio.central.discovery/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <groupId>com.jboss.devstudio.core.plugins</groupId>
   <artifactId>com.jboss.devstudio.central.discovery</artifactId> 
-  <version>11.0.0-SNAPSHOT</version>
+  <version>11.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 <build>
     <plugins>


### PR DESCRIPTION
There is com.jboss.devstudio.central.discovery_11.0.0.AM2-v20170920-0808-B2192.jar at [1] but there should be 11.1.0. Central is working fine so this is not urgent but it should be fixed.

[1] https://devstudio.redhat.com/11/snapshots/updates/discovery.earlyaccess/master/plugins/

Signed-off-by: Lukáš Valach <lvalach@redhat.com>