### PR TITLE
JBIDE-24897 add fabric8analytics to Central...

### DIFF
--- a/devstudio/com.jboss.devstudio.central.discovery.earlyaccess/plugin.xml
+++ b/devstudio/com.jboss.devstudio.central.discovery.earlyaccess/plugin.xml
@@ -82,7 +82,7 @@ appropriate tests + report issues to plug-in providers as required.</description
          <overview url="http://windup.jboss.org/"/>
       </connectorDescriptor> -->
 
-      <!-- JBIDE-24897 fabric8 analytics not ready yet 
+      <!-- JBIDE-24897 fabric8 analytics  -->
       <connectorDescriptor
             categoryId="org.jboss.tools.central.discovery.a.web"
             groupId="org.jboss.tools.central.discovery.a.web.core"
@@ -93,11 +93,10 @@ appropriate tests + report issues to plug-in providers as required.</description
             license="EPL (Free)"
             name="Fabric8 Analytics Language Server Integration"
             provider="JBoss by Red Hat"
-            siteUrl="${jboss.discovery.earlyaccess.site.url}">
+            siteUrl="http://download.jboss.org/jbosstools/oxygen/development/updates/fabric8analytics/">
             <iu id="com.redhat.fabric8analytics.lsp.eclipse.feature" />
          <icon image32="images/devstudio_icon32.png"/>
          <overview url="https://github.com/fabric8-analytics/fabric8-analytics-devstudio-plugin/"/>
-      </connectorDescriptor> -->
-
+      </connectorDescriptor>
     </extension>	
 </plugin>

--- a/jbosstools/org.jboss.tools.central.discovery.earlyaccess/plugin.xml
+++ b/jbosstools/org.jboss.tools.central.discovery.earlyaccess/plugin.xml
@@ -69,7 +69,7 @@ appropriate tests + report issues to plug-in providers as required.</description
          <overview url="http://windup.jboss.org/"/>
       </connectorDescriptor> -->
 
-      <!-- JBIDE-24897 fabric8 analytics not ready yet
+      <!-- JBIDE-24897 fabric8 analytics -->
       <connectorDescriptor
             categoryId="org.jboss.tools.central.discovery.a.web"
             groupId="org.jboss.tools.central.discovery.a.web.core"
@@ -80,11 +80,10 @@ appropriate tests + report issues to plug-in providers as required.</description
             license="EPL (Free)"
             name="Fabric8 Analytics Language Server Integration"
             provider="JBoss by Red Hat"
-            siteUrl="${jboss.discovery.earlyaccess.site.url}">
+            siteUrl="http://download.jboss.org/jbosstools/oxygen/development/updates/fabric8analytics/">
             <iu id="com.redhat.fabric8analytics.lsp.eclipse.feature" />
          <icon image32="images/jbosstools_icon32.png"/>
          <overview url="https://github.com/fabric8-analytics/fabric8-analytics-devstudio-plugin/"/>
-      </connectorDescriptor> -->
-
+      </connectorDescriptor>
     </extension>
 </plugin>


### PR DESCRIPTION
JBIDE-24897 add fabric8analytics to Central EA, via its own update site http://download.jboss.org/jbosstools/oxygen/development/updates/fabric8analytics/

Signed-off-by: nickboldt <nboldt@redhat.com>