### PR TITLE
JBIDE-24897 move Fabric8 Analytics to...

### DIFF
--- a/devstudio/com.jboss.devstudio.central.discovery.earlyaccess/plugin.xml
+++ b/devstudio/com.jboss.devstudio.central.discovery.earlyaccess/plugin.xml
@@ -14,6 +14,16 @@ so that it can be evaluated + monitored, in order to execute
 appropriate tests + report issues to plug-in providers as required.</description>
          <icon image48="images/redhat_48.png"></icon>
       </certification>
+      <certification id="com.jboss.devstudio.discovery.certification.techpreview.earlyaccess" name="Technology Preview - Early Access" url="https://devstudio.redhat.com/11/stable/updates/#central">
+         <description>Tested by Red Hat. However, as these are Technology Preview
+plug-ins, it is possible that their content may change at 
+any time and without prior notice. 
+ 
+This content is provided via Early Access 
+so that it can be evaluated + monitored, in order to execute 
+appropriate tests + report issues as required.</description>
+         <icon image48="images/jbosstools_48.png"></icon>
+      </certification>
       <certification id="com.jboss.devstudio.discovery.certification.supported.earlyaccess" name="Supported - Early Access" url="https://devstudio.redhat.com/11/stable/updates/#central">
          <description>Supported by Red Hat.
  
@@ -86,7 +96,7 @@ appropriate tests + report issues to plug-in providers as required.</description
       <connectorDescriptor
             categoryId="org.jboss.tools.central.discovery.a.web"
             groupId="org.jboss.tools.central.discovery.a.web.core"
-            certificationId="com.jboss.devstudio.discovery.certification.supported.earlyaccess"
+            certificationId="com.jboss.devstudio.discovery.certification.techpreview.earlyaccess"
             description="Fabric8 Analytics Language Server Integration helps to analyze the components of your application stack as you type."
             id="com.redhat.fabric8analytics.lsp"
             kind="task"

--- a/jbosstools/org.jboss.tools.central.discovery.earlyaccess/plugin.xml
+++ b/jbosstools/org.jboss.tools.central.discovery.earlyaccess/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
-	<extension point="org.eclipse.mylyn.discovery.core.connectorDiscovery">
+   <extension point="org.eclipse.mylyn.discovery.core.connectorDiscovery">
       <certification id="org.jboss.tools.discovery.certification.experimental.earlyaccess" name="Experimental - Early Access" url="https://devstudio.redhat.com/11/stable/updates/#central">
          <description>Tested by Red Hat. However, as these are experimental plug-ins,
 it is possible that their content may change at any time and
@@ -12,6 +12,16 @@ reasonable, reporting issues to these providers as required.
 This content is provided via Early Access 
 so that it can be evaluated + monitored, in order to execute 
 appropriate tests + report issues to plug-in providers as required.</description>
+         <icon image48="images/jbosstools_48.png"></icon>
+      </certification>
+      <certification id="org.jboss.tools.discovery.certification.techpreview.earlyaccess" name="Technology Preview - Early Access" url="https://devstudio.redhat.com/11/stable/updates/#central">
+         <description>Tested by Red Hat. However, as these are Technology Preview
+plug-ins, it is possible that their content may change at 
+any time and without prior notice. 
+
+This content is provided via Early Access 
+so that it can be evaluated + monitored, in order to execute 
+appropriate tests + report issues as required.</description>
          <icon image48="images/jbosstools_48.png"></icon>
       </certification>
       <certification id="org.jboss.tools.discovery.certification.supported.earlyaccess" name="Supported - Early Access" url="https://devstudio.redhat.com/11/stable/updates/#central">
@@ -73,7 +83,7 @@ appropriate tests + report issues to plug-in providers as required.</description
       <connectorDescriptor
             categoryId="org.jboss.tools.central.discovery.a.web"
             groupId="org.jboss.tools.central.discovery.a.web.core"
-            certificationId="org.jboss.tools.discovery.certification.supported.earlyaccess"
+            certificationId="org.jboss.tools.discovery.certification.techpreview.earlyaccess"
             description="Fabric8 Analytics Language Server Integration helps to analyze the components of your application stack as you type."
             id="com.redhat.fabric8analytics.lsp"
             kind="task"
@@ -85,5 +95,5 @@ appropriate tests + report issues to plug-in providers as required.</description
          <icon image32="images/jbosstools_icon32.png"/>
          <overview url="https://github.com/fabric8-analytics/fabric8-analytics-devstudio-plugin/"/>
       </connectorDescriptor>
-    </extension>
+   </extension>
 </plugin>


### PR DESCRIPTION
JBIDE-24897 move Fabric8 Analytics to certification.techpreview.earlyaccess (was certification.supported.earlyaccess); add new <certification> values for certification.supported.earlyaccess

Signed-off-by: nickboldt <nboldt@redhat.com>