### PR TITLE
JBIDE-27327 : Update 4.16.0.Final Target Platform for 2020-06 GA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+/.project
+bin/

--- a/jbtcentraltarget/multiple/jbtcentral-multiple.target
+++ b/jbtcentraltarget/multiple/jbtcentral-multiple.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.6"?>
-<target includeMode="feature" name="jbtcentral-4.16.0.AM1-SNAPSHOT">
+<target includeMode="feature" name="jbtcentral-4.16.0.Final-SNAPSHOT">
   <!-- Pro tip: paste content from generated Apache directory index, then match
         \[ ] (.+)_(.+).jar.+
     replace with 
@@ -26,50 +26,49 @@
 
     <!-- required for SpringIDE (see also above) -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/springide/3.9.12.202003180620-RELEASE/"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/springide/3.9.13.202006180736-RELEASE/"/>
       <!-- Features to include in Central connector -->
-      <unit id="org.springframework.ide.eclipse.aop.feature.feature.group" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.autowire.feature.feature.group" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.batch.feature.feature.group" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.data.feature.feature.group" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.feature.feature.group" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.beans.ui.live" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.beans.ui.livegraph" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.boot" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.boot.wizard" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.editor.support" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.maven.pom" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.integration.feature.feature.group" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.maven.feature.feature.group" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.mylyn.feature.feature.group" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.osgi.feature.feature.group" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.security.feature.feature.group" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.webflow.feature.feature.group" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.xml.namespaces.feature.feature.group" version="3.9.12.202003180620-RELEASE"/> <!-- new as of 3.9.9 -->
+      <unit id="org.springframework.ide.eclipse.aop.feature.feature.group" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.autowire.feature.feature.group" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.batch.feature.feature.group" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.data.feature.feature.group" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.feature.feature.group" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.beans.ui.live" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.beans.ui.livegraph" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.boot" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.boot.wizard" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.editor.support" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.maven.pom" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.integration.feature.feature.group" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.maven.feature.feature.group" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.mylyn.feature.feature.group" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.osgi.feature.feature.group" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.security.feature.feature.group" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.webflow.feature.feature.group" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.xml.namespaces.feature.feature.group" version="3.9.13.202006180736-RELEASE"/> <!-- new as of 3.9.9 -->
 
       <!-- depends on mylyn (used to be contained in org.springsource.ide.eclipse.commons.feature but feature was removed as of 3.9.3) -->
       <unit id="io.projectreactor.reactor-core" version="3.3.1.202003091750-RELEASE"/>
       <unit id="org.reactivestreams.reactive-streams" version="1.0.3"/>
-      <unit id="org.springsource.ide.eclipse.commons.configurator" version="3.9.12.202003180611-RELEASE"/>
-      <unit id="org.springsource.ide.eclipse.commons.content.core" version="3.9.12.202003180611-RELEASE"/>
-      <unit id="org.springsource.ide.eclipse.commons.core" version="3.9.12.202003180611-RELEASE"/>
-      <unit id="org.springsource.ide.eclipse.commons.frameworks.core" version="3.9.12.202003180611-RELEASE"/>
-      <unit id="org.springsource.ide.eclipse.commons.frameworks.ui" version="3.9.12.202003180611-RELEASE"/>
-      <unit id="org.springsource.ide.eclipse.commons.jdk_tools" version="3.9.12.202003180611-RELEASE"/>
-      <unit id="org.springsource.ide.eclipse.commons.livexp" version="3.9.12.202003180611-RELEASE"/>
-      <unit id="org.springsource.ide.eclipse.commons.ui" version="3.9.12.202003180611-RELEASE"/>
+      <unit id="org.springsource.ide.eclipse.commons.content.core" version="3.9.13.202006180733-RELEASE"/>
+      <unit id="org.springsource.ide.eclipse.commons.core" version="3.9.13.202006180733-RELEASE"/>
+      <unit id="org.springsource.ide.eclipse.commons.frameworks.core" version="3.9.13.202006180733-RELEASE"/>
+      <unit id="org.springsource.ide.eclipse.commons.frameworks.ui" version="3.9.13.202006180733-RELEASE"/>
+      <unit id="org.springsource.ide.eclipse.commons.jdk_tools" version="3.9.13.202006180733-RELEASE"/>
+      <unit id="org.springsource.ide.eclipse.commons.livexp" version="3.9.13.202006180733-RELEASE"/>
+      <unit id="org.springsource.ide.eclipse.commons.ui" version="3.9.13.202006180733-RELEASE"/>
 
       <!-- Plugins to include to avoid console warnings after installation -->
-      <unit id="org.springframework.ide.eclipse.config.ui" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.maven" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.wizard" version="3.9.12.202003180620-RELEASE"/>
-      <unit id="org.springsource.ide.eclipse.dashboard.ui" version="3.9.12.202003180611-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.config.ui" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.maven" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.wizard" version="3.9.13.202006180736-RELEASE"/>
+      <unit id="org.springsource.ide.eclipse.dashboard.ui" version="3.9.13.202006180733-RELEASE"/>
 
       <!-- Required 3rd party plugins (on SpringIDE or Orbit site) not properly referenced by features -->
       <unit id="javax.jms" version="1.1.0.v201205091237"/>
-      <unit id="org.aspectj.runtime" version="1.9.2.202002051807"/>
-      <unit id="org.aspectj.weaver" version="1.9.2.202002051807"/>
-      <unit id="org.eclipse.equinox.weaving.sdk.feature.group" version="1.2.0.202002051807"/>
+      <unit id="org.aspectj.runtime" version="1.9.6.202004271746"/>
+      <unit id="org.aspectj.weaver" version="1.9.6.202004271746"/>
+      <unit id="org.eclipse.equinox.weaving.sdk.feature.group" version="1.2.0.202004271746"/>
       <unit id="org.eclipse.equinox.weaving.hook" version="1.2.200.v20180827-1235"/>
     </location>
 

--- a/jbtcentraltarget/multiple/pom.xml
+++ b/jbtcentraltarget/multiple/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbtcentral</artifactId>
-		<version>4.16.0.AM1-SNAPSHOT</version>
+		<version>4.16.0.Final-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbtcentral-multiple</artifactId>
 	<name>JBoss Central Core Multiple (Composite) Target Platform</name>

--- a/jbtcentraltarget/pom.xml
+++ b/jbtcentraltarget/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbtcentral</artifactId>
-	<version>4.16.0.AM1-SNAPSHOT</version>
+	<version>4.16.0.Final-SNAPSHOT</version>
 	<name>JBoss Central Core Target Platforms</name>
 	<packaging>pom</packaging>
 

--- a/jbtearlyaccesstarget/multiple/jbtearlyaccess-multiple.target
+++ b/jbtearlyaccesstarget/multiple/jbtearlyaccess-multiple.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.6"?>
-<target includeMode="feature" name="jbtearlyaccess-4.16.0.AM1-SNAPSHOT">
+<target includeMode="feature" name="jbtearlyaccess-4.16.0.Final-SNAPSHOT">
   <!-- Pro tip: paste content from generated Apache directory index, then match
         \[ ] (.+)_(.+).jar.+
     replace with 

--- a/jbtearlyaccesstarget/multiple/pom.xml
+++ b/jbtearlyaccesstarget/multiple/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbtearlyaccess</artifactId>
-		<version>4.16.0.AM1-SNAPSHOT</version>
+		<version>4.16.0.Final-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbtearlyaccess-multiple</artifactId>
 	<name>JBoss Central Early Access Multiple (Composite) Target Platform</name>

--- a/jbtearlyaccesstarget/pom.xml
+++ b/jbtearlyaccesstarget/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbtearlyaccess</artifactId>
-	<version>4.16.0.AM1-SNAPSHOT</version>
+	<version>4.16.0.Final-SNAPSHOT</version>
 	<name>JBoss Central Early Access Target Platforms</name>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
added springide 3.9.13.202006180736-RELEASE

Signed-off-by: Stephane Bouchet <sbouchet@redhat.com>