### PR TITLE
JBIDE-27651: Update 4.19.0.AM1 Target Platform for 2021-03

### DIFF
--- a/devstudio/com.jboss.devstudio.central.discovery.earlyaccess/pom.xml
+++ b/devstudio/com.jboss.devstudio.central.discovery.earlyaccess/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.tools.central.discovery</groupId>
     <artifactId>devstudio</artifactId>
-    <version>4.18.0-SNAPSHOT</version>
+    <version>4.19.0-SNAPSHOT</version>
   </parent>
   <groupId>com.jboss.devstudio.core.plugins</groupId>
   <artifactId>com.jboss.devstudio.central.discovery.earlyaccess</artifactId> 
@@ -15,7 +15,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.7</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>install</id>
@@ -52,32 +52,22 @@
           <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
-            <version>1.4.1</version>
+            <version>3.8.0</version>
           </dependency>
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.7.1</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant-nodeps</artifactId>
-            <version>1.7.1</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant-trax</artifactId>
-            <version>1.7.1</version>
+            <version>${antVersion}</version>
           </dependency>
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-commons-net</artifactId>
-            <version>1.7.1</version>
+            <version>${antVersion}</version>
           </dependency>
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-apache-regexp</artifactId>
-            <version>1.7.1</version>
+            <version>${antVersion}</version>
           </dependency>
           <dependency>
             <groupId>ant-contrib</groupId>

--- a/devstudio/com.jboss.devstudio.central.discovery/pom.xml
+++ b/devstudio/com.jboss.devstudio.central.discovery/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss.tools.central.discovery</groupId>
     <artifactId>devstudio</artifactId>
-    <version>4.18.0-SNAPSHOT</version>
+    <version>4.19.0-SNAPSHOT</version>
   </parent>
   <groupId>com.jboss.devstudio.core.plugins</groupId>
   <artifactId>com.jboss.devstudio.central.discovery</artifactId> 
@@ -15,7 +15,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.7</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>install</id>
@@ -52,32 +52,22 @@
           <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
-            <version>1.4.1</version>
+            <version>3.8.0</version>
           </dependency>
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.7.1</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant-nodeps</artifactId>
-            <version>1.7.1</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant-trax</artifactId>
-            <version>1.7.1</version>
+            <version>${antVersion}</version>
           </dependency>
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-commons-net</artifactId>
-            <version>1.7.1</version>
+            <version>${antVersion}</version>
           </dependency>
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-apache-regexp</artifactId>
-            <version>1.7.1</version>
+            <version>${antVersion}</version>
           </dependency>
           <dependency>
             <groupId>ant-contrib</groupId>

--- a/devstudio/pom.xml
+++ b/devstudio/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.central</groupId>
 		<artifactId>discovery</artifactId>
-		<version>4.18.0-SNAPSHOT</version>
+		<version>4.19.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central.discovery</groupId>
 	<artifactId>devstudio</artifactId>

--- a/jbosstools/org.jboss.tools.central.discovery.earlyaccess/META-INF/MANIFEST.MF
+++ b/jbosstools/org.jboss.tools.central.discovery.earlyaccess/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: org.jboss.tools.central.discovery.earlyaccess;singleton:=true
-Bundle-Version: 4.18.0.qualifier
+Bundle-Version: 4.19.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.mylyn.discovery.core;bundle-version="3.6.0"
 Bundle-ActivationPolicy: lazy

--- a/jbosstools/org.jboss.tools.central.discovery.earlyaccess/pom.xml
+++ b/jbosstools/org.jboss.tools.central.discovery.earlyaccess/pom.xml
@@ -4,18 +4,18 @@
   <parent>
     <groupId>org.jboss.tools.central.discovery</groupId>
     <artifactId>jbosstools</artifactId>
-    <version>4.18.0-SNAPSHOT</version>
+    <version>4.19.0-SNAPSHOT</version>
   </parent>
   <groupId>org.jboss.tools.central.plugins</groupId>
   <artifactId>org.jboss.tools.central.discovery.earlyaccess</artifactId> 
-  <version>4.18.0-SNAPSHOT</version>
+  <version>4.19.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.7</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>install</id>
@@ -52,32 +52,22 @@
           <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
-            <version>1.4.1</version>
+            <version>3.8.0</version>
           </dependency>
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.7.1</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant-nodeps</artifactId>
-            <version>1.7.1</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant-trax</artifactId>
-            <version>1.7.1</version>
+            <version>${antVersion}</version>
           </dependency>
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-commons-net</artifactId>
-            <version>1.7.1</version>
+            <version>${antVersion}</version>
           </dependency>
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-apache-regexp</artifactId>
-            <version>1.7.1</version>
+            <version>${antVersion}</version>
           </dependency>
           <dependency>
             <groupId>ant-contrib</groupId>

--- a/jbosstools/org.jboss.tools.central.discovery/META-INF/MANIFEST.MF
+++ b/jbosstools/org.jboss.tools.central.discovery/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %BundleName
 Bundle-SymbolicName: org.jboss.tools.central.discovery;singleton:=true
-Bundle-Version: 4.18.0.qualifier
+Bundle-Version: 4.19.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.mylyn.discovery.core;bundle-version="3.6.0"
 Bundle-ActivationPolicy: lazy

--- a/jbosstools/org.jboss.tools.central.discovery/pom.xml
+++ b/jbosstools/org.jboss.tools.central.discovery/pom.xml
@@ -4,18 +4,18 @@
   <parent>
     <groupId>org.jboss.tools.central.discovery</groupId>
     <artifactId>jbosstools</artifactId>
-    <version>4.18.0-SNAPSHOT</version>
+    <version>4.19.0-SNAPSHOT</version>
   </parent>
   <groupId>org.jboss.tools.central.plugins</groupId>
   <artifactId>org.jboss.tools.central.discovery</artifactId> 
-  <version>4.18.0-SNAPSHOT</version>
+  <version>4.19.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.7</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>install</id>
@@ -52,32 +52,22 @@
           <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
-            <version>1.4.1</version>
+            <version>3.8.0</version>
           </dependency>
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.7.1</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant-nodeps</artifactId>
-            <version>1.7.1</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.ant</groupId>
-            <artifactId>ant-trax</artifactId>
-            <version>1.7.1</version>
+            <version>${antVersion}</version>
           </dependency>
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-commons-net</artifactId>
-            <version>1.7.1</version>
+            <version>${antVersion}</version>
           </dependency>
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-apache-regexp</artifactId>
-            <version>1.7.1</version>
+            <version>${antVersion}</version>
           </dependency>
           <dependency>
             <groupId>ant-contrib</groupId>

--- a/jbosstools/pom.xml
+++ b/jbosstools/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.central</groupId>
 		<artifactId>discovery</artifactId>
-		<version>4.18.0-SNAPSHOT</version>
+		<version>4.19.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.central.discovery</groupId>
 	<artifactId>jbosstools</artifactId>

--- a/jbtcentraltarget/multiple/jbtcentral-multiple.target
+++ b/jbtcentraltarget/multiple/jbtcentral-multiple.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.6"?>
-<target includeMode="feature" name="jbtcentral-4.17.0.Final-SNAPSHOT">
+<target includeMode="feature" name="jbtcentral-4.19.0.AM1-SNAPSHOT">
   <!-- Pro tip: paste content from generated Apache directory index, then match
         \[ ] (.+)_(.+).jar.+
     replace with 
@@ -14,79 +14,79 @@
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/eclipsecs/8.35.0.202008141925/"/>
-      <unit id="com.github.sevntu.checkstyle.checks.feature.feature.group" version="1.37.1"/>
-      <unit id="net.sf.eclipsecs.feature.group" version="8.35.0.202008141925"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/eclipsecs/8.36.1.202101292258/"/>
+      <unit id="com.github.sevntu.checkstyle.checks.feature.feature.group" version="1.38.0"/>
+      <unit id="net.sf.eclipsecs.feature.group" version="8.36.1.202101292258"/>
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/sonarlint/5.3.0.19940/"/>
-      <unit id="org.sonarlint.eclipse.feature.feature.group" version="5.3.0.19940"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/sonarlint/5.7.0.28269/"/>
+      <unit id="org.sonarlint.eclipse.feature.feature.group" version="5.7.0.28269"/>
     </location>
 
     <!-- required for SpringIDE (see also above) -->
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/springide/3.9.14.202009150957-RELEASE/"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/springide/3.9.15.202012140048-RELEASE/"/>
       <!-- Features to include in Central connector -->
-      <unit id="org.springframework.ide.eclipse.aop.feature.feature.group" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.autowire.feature.feature.group" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.batch.feature.feature.group" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.data.feature.feature.group" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.feature.feature.group" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.beans.ui.live" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.beans.ui.livegraph" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.boot" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.boot.wizard" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.editor.support" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.maven.pom" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.integration.feature.feature.group" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.maven.feature.feature.group" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.mylyn.feature.feature.group" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.osgi.feature.feature.group" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.security.feature.feature.group" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.webflow.feature.feature.group" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.xml.namespaces.feature.feature.group" version="3.9.14.202009150957-RELEASE"/> <!-- new as of 3.9.9 -->
+      <unit id="org.springframework.ide.eclipse.aop.feature.feature.group" version="3.9.15.202012140048-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.autowire.feature.feature.group" version="3.9.15.202012140048-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.batch.feature.feature.group" version="3.9.15.202012140048-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.data.feature.feature.group" version="3.9.15.202012140048-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.feature.feature.group" version="3.9.15.202012140048-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.beans.ui.live" version="4.9.0.202012132054"/>
+      <unit id="org.springframework.ide.eclipse.beans.ui.livegraph" version="3.9.15.202012140048-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.boot" version="4.9.0.202012132054"/>
+      <unit id="org.springframework.ide.eclipse.boot.wizard" version="4.9.0.202012132054"/>
+      <unit id="org.springframework.ide.eclipse.editor.support" version="4.9.0.202012131915"/>
+      <unit id="org.springframework.ide.eclipse.maven.pom" version="4.9.0.202012132054"/>
+      <unit id="org.springframework.ide.eclipse.integration.feature.feature.group" version="3.9.15.202012140048-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.maven.feature.feature.group" version="3.9.15.202012140048-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.mylyn.feature.feature.group" version="3.9.15.202012140048-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.osgi.feature.feature.group" version="3.9.15.202012140048-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.security.feature.feature.group" version="3.9.15.202012140048-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.webflow.feature.feature.group" version="3.9.15.202012140048-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.xml.namespaces.feature.feature.group" version="4.9.0.202012132054"/> <!-- new as of 3.9.9 -->
 
       <!-- depends on mylyn (used to be contained in org.springsource.ide.eclipse.commons.feature but feature was removed as of 3.9.3) -->
       <unit id="io.projectreactor.reactor-core" version="3.3.1.202003091750-RELEASE"/>
       <unit id="org.reactivestreams.reactive-streams" version="1.0.3"/>
-      <unit id="org.springsource.ide.eclipse.commons.content.core" version="3.9.14.202009150831-RELEASE"/>
-      <unit id="org.springsource.ide.eclipse.commons.core" version="3.9.14.202009150831-RELEASE"/>
-      <unit id="org.springsource.ide.eclipse.commons.frameworks.core" version="3.9.14.202009150831-RELEASE"/>
-      <unit id="org.springsource.ide.eclipse.commons.frameworks.ui" version="3.9.14.202009150831-RELEASE"/>
-      <unit id="org.springsource.ide.eclipse.commons.jdk_tools" version="3.9.14.202009150831-RELEASE"/>
-      <unit id="org.springsource.ide.eclipse.commons.livexp" version="3.9.14.202009150831-RELEASE"/>
-      <unit id="org.springsource.ide.eclipse.commons.ui" version="3.9.14.202009150831-RELEASE"/>
+      <unit id="org.springsource.ide.eclipse.commons.content.core" version="3.9.15.202012132153-RELEASE"/>
+      <unit id="org.springsource.ide.eclipse.commons.core" version="4.9.0.202012131915"/>
+      <unit id="org.springsource.ide.eclipse.commons.frameworks.core" version="4.9.0.202012131915"/>
+      <unit id="org.springsource.ide.eclipse.commons.frameworks.ui" version="4.9.0.202012131915"/>
+      <unit id="org.springsource.ide.eclipse.commons.jdk_tools" version="4.9.0.202012131915"/>
+      <unit id="org.springsource.ide.eclipse.commons.livexp" version="4.9.0.202012131915"/>
+      <unit id="org.springsource.ide.eclipse.commons.ui" version="4.9.0.202012131915"/>
 
       <!-- Plugins to include to avoid console warnings after installation -->
-      <unit id="org.springframework.ide.eclipse.config.ui" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.maven" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springframework.ide.eclipse.wizard" version="3.9.14.202009150957-RELEASE"/>
-      <unit id="org.springsource.ide.eclipse.dashboard.ui" version="3.9.14.202009150831-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.config.ui" version="3.9.15.202012140048-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.maven" version="3.9.15.202012140048-RELEASE"/>
+      <unit id="org.springframework.ide.eclipse.wizard" version="3.9.15.202012140048-RELEASE"/>
+      <unit id="org.springsource.ide.eclipse.dashboard.ui" version="3.9.15.202012132153-RELEASE"/>
 
       <!-- Required 3rd party plugins (on SpringIDE or Orbit site) not properly referenced by features -->
       <unit id="javax.jms" version="1.1.0.v201205091237"/>
-      <unit id="org.aspectj.runtime" version="1.9.6.202007241909"/>
-      <unit id="org.aspectj.weaver" version="1.9.6.202007241909"/>
-      <unit id="org.eclipse.equinox.weaving.sdk.feature.group" version="1.2.0.202007241909"/>
+      <unit id="org.aspectj.runtime" version="1.9.6.202012111622"/>
+      <unit id="org.aspectj.weaver" version="1.9.6.202012111622"/>
+      <unit id="org.eclipse.equinox.weaving.sdk.feature.group" version="1.2.0.202012111622"/>
       <unit id="org.eclipse.equinox.weaving.hook" version="1.2.200.v20180827-1235"/>
 
       <unit id="org.dadacoalition.yedit" version="1.0.18.201602092025-RELEASE-SIGNED"/>
     </location>
 
     <location includeAllPlatforms="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <repository location="https://download.jboss.org/jbosstools/updates/requirements/subclipse/4.3.0.201901172050/"/>
+      <repository location="https://download.jboss.org/jbosstools/updates/requirements/subclipse/4.3.3.202012181204/"/>
       <unit id="com.collabnet.subversion.merge" version="4.2.0.1"/>
       <unit id="net.java.dev.jna.feature.group" version="4.1.0.v06022015_1911"/>
       <unit id="org.tigris.subversion.clientadapter" version="1.10.0"/>
-      <unit id="org.tigris.subversion.clientadapter.javahl.feature.feature.group" version="1.14.0.202005041822"/>
+      <unit id="org.tigris.subversion.clientadapter.javahl.feature.feature.group" version="1.14.0.202005311413"/>
       <unit id="org.tigris.subversion.clientadapter.svnkit.feature.feature.group" version="1.8.12.3"/>
       <unit id="org.tigris.subversion.subclipse.graph.feature.feature.group" version="4.2.0.1"/>
       <unit id="org.tigris.subversion.subclipse.mylyn.feature.feature.group" version="4.2.0.1"/>
-      <unit id="org.tigris.subversion.subclipse.feature.group" version="4.3.0.201901172050"/>
-      <unit id="org.tmatesoft.svnkit.feature.group" version="1.8.12.r10533_v20160129_0158"/>
+      <unit id="org.tigris.subversion.subclipse.feature.group" version="4.3.3.202012181204"/>
+      <unit id="org.tmatesoft.svnkit.feature.group" version="1.10.2.r10793"/>
     </location>
 
   </locations>
-  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 </target>

--- a/jbtcentraltarget/multiple/pom.xml
+++ b/jbtcentraltarget/multiple/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbtcentral</artifactId>
-		<version>4.17.0.Final-SNAPSHOT</version>
+		<version>4.19.0.AM1-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbtcentral-multiple</artifactId>
 	<name>JBoss Central Core Multiple (Composite) Target Platform</name>

--- a/jbtcentraltarget/pom.xml
+++ b/jbtcentraltarget/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>org.jboss.tools.central</groupId>
 		<artifactId>discovery</artifactId>
-		<version>4.18.0-SNAPSHOT</version>
+		<version>4.19.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbtcentral</artifactId>
-	<version>4.17.0.Final-SNAPSHOT</version>
+	<version>4.19.0.AM1-SNAPSHOT</version>
 	<name>JBoss Central Core Target Platforms</name>
 	<packaging>pom</packaging>
 

--- a/jbtearlyaccesstarget/multiple/jbtearlyaccess-multiple.target
+++ b/jbtearlyaccesstarget/multiple/jbtearlyaccess-multiple.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><?pde version="3.6"?>
-<target includeMode="feature" name="jbtearlyaccess-4.17.0.Final-SNAPSHOT">
+<target includeMode="feature" name="jbtearlyaccess-4.18.0.AM1-SNAPSHOT">
   <!-- Pro tip: paste content from generated Apache directory index, then match
         \[ ] (.+)_(.+).jar.+
     replace with 

--- a/jbtearlyaccesstarget/multiple/pom.xml
+++ b/jbtearlyaccesstarget/multiple/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.targetplatforms</groupId>
 		<artifactId>jbtearlyaccess</artifactId>
-		<version>4.17.0.Final-SNAPSHOT</version>
+		<version>4.19.0.AM1-SNAPSHOT</version>
 	</parent>
 	<artifactId>jbtearlyaccess-multiple</artifactId>
 	<name>JBoss Central Early Access Multiple (Composite) Target Platform</name>

--- a/jbtearlyaccesstarget/pom.xml
+++ b/jbtearlyaccesstarget/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>org.jboss.tools.central</groupId>
 		<artifactId>discovery</artifactId>
-		<version>4.18.0-SNAPSHOT</version>
+		<version>4.19.0-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.targetplatforms</groupId>
 	<artifactId>jbtearlyaccess</artifactId>
-	<version>4.17.0.Final-SNAPSHOT</version>
+	<version>4.19.0.AM1-SNAPSHOT</version>
 	<name>JBoss Central Early Access Target Platforms</name>
 	<packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<groupId>org.jboss.tools.central</groupId>
 	<artifactId>discovery</artifactId>
-	<version>4.18.0-SNAPSHOT</version>
+	<version>4.19.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<properties>
@@ -16,6 +16,7 @@
 		<!-- <tychoExtrasVersion>${tychoVersion}</tychoExtrasVersion> -->
 		<!-- <jbossTychoPluginsVersion>1.1.0</jbossTychoPluginsVersion> -->
 		<tycho.scmUrl>scm:git:https://github.com/jbosstools/jbosstools-discovery.git</tycho.scmUrl>
+		<antVersion>1.10.9</antVersion>
 	</properties>
 	<!-- this pom will only build the discovery plugins, not the target platforms. See README.adoc for building target platforms -->
 	<modules>


### PR DESCRIPTION
subclipse 4.3.3.202012181204
springide 3.9.15.202012140048-RELEASE
eclipsecs 8.36.1.202101292258
sonarlint 5.7.0.28269

Signed-off-by: Stephane Bouchet <sbouchet@redhat.com>